### PR TITLE
Fix: Resolve dropbear interface bind race condition on boot (#1)

### DIFF
--- a/root_fs/etc/init.d/dropbear
+++ b/root_fs/etc/init.d/dropbear
@@ -123,6 +123,15 @@ service_triggers()
 {
 	procd_add_reload_trigger "dropbear"
 	procd_add_validation validate_section_dropbear
+
+	trigger_dropbear_interface() {
+		local interface
+		config_get interface "$1" Interface
+		[ -n "$interface" ] && procd_add_reload_interface_trigger "$interface"
+	}
+	
+	config_load "${NAME}"
+	config_foreach trigger_dropbear_interface dropbear
 }
 
 killclients()

--- a/xx3301/image_builder/openwrt_root/etc/init.d/dropbear
+++ b/xx3301/image_builder/openwrt_root/etc/init.d/dropbear
@@ -123,6 +123,15 @@ service_triggers()
 {
 	procd_add_reload_trigger "dropbear"
 	procd_add_validation validate_section_dropbear
+
+	trigger_dropbear_interface() {
+		local interface
+		config_get interface "$1" Interface
+		[ -n "$interface" ] && procd_add_reload_interface_trigger "$interface"
+	}
+	
+	config_load "${NAME}"
+	config_foreach trigger_dropbear_interface dropbear
 }
 
 killclients()


### PR DESCRIPTION
Fixes #1

This PR addresses the issue where configuring Dropbear SSH to bind to a specific interface causes it to fail upon reboot. 

### Cause
The failure happens because early in the boot sequence, the requested interface has not yet obtained an IP address, causing the initial validation check (`network_get_ipaddrs_all`) to fail and prevent Dropbear from starting.

### Solution
This fix utilizes native `procd` triggers to gracefully handle this. By dynamically reading the configured `Interface` and adding it via `procd_add_reload_interface_trigger`, the init system will monitor the interface state and automatically reload the Dropbear service as soon as the interface comes up and obtains an IP address.

**Disclaimer:** This code was entirely AI-generated using Google's `gemini-flash-lite-latest` model. It is currently untested and is provided as a suggestion based on standard OpenWrt `procd` patterns.