### PR TITLE
Run /etc/firewall.user at boot, after NAT flushes and on WAN up; larger log buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,39 @@ Run the "repack_firmware" , it will transfer the signature from the ISP-specific
 |------|------------|-----------|---------------|-------|
 | **AP Mode** | 192.168.1.1 | Zyxel_Matrix | 12345678 | root/1234 |
 
+## 🔥 Custom firewall rules and logging
+
+This firmware does not ship the OpenWrt firewall service (`/etc/init.d/firewall` / `fw3`):
+netfilter is configured by the Zyxel side (`zyxel_lan`, `wifi-backhaul.sh`). Because of that,
+rules written to `/etc/firewall.user` (LuCI → Network → Firewall → Custom Rules) were never
+executed and silently disappeared on every reboot.
+
+Since this change `/usr/sbin/apply-firewall-user` runs `/etc/firewall.user`:
+
+- at the end of boot (`zyxel_lan`),
+- after every NAT flush done by `wifi-backhaul.sh`,
+- on every `ifup` of the WAN interface (hotplug), i.e. after each PPPoE reconnect.
+
+The file is therefore executed several times: write **idempotent** rules, for example
+
+```sh
+# block a LAN device from reaching the Internet
+iptables -C FORWARD -s 192.168.1.50 -o pppoe-wan -j DROP 2>/dev/null || \
+  iptables -I FORWARD 1 -s 192.168.1.50 -o pppoe-wan -j DROP
+```
+
+**Logs.** The default `logd` ring buffer was 16 KiB (a couple of minutes of Zyxel `zcmd`
+chatter) and nothing survives a reboot. The default is now 256 KiB (`log_size` in
+`/etc/config/system`). To keep the last lines before a crash/reboot, send the log to another
+machine on the LAN:
+
+```sh
+uci set system.@system[0].log_ip='192.168.1.10'   # any host running a syslog UDP receiver
+uci set system.@system[0].log_port='514'
+uci set system.@system[0].log_proto='udp'
+uci commit system && /etc/init.d/log restart
+```
+
 ## 🛠️ Development
 
 This project include busybox based on OpenWrt. To build from source:

--- a/root_fs/etc/config/system
+++ b/root_fs/etc/config/system
@@ -5,6 +5,7 @@ config system
     option log_proto 'udp'
     option conloglevel '8'
     option cronloglevel '5'
+    option log_size '256'
 
 config timeserver 'ntp'
     list server '0.openwrt.pool.ntp.org'

--- a/root_fs/etc/firewall.user
+++ b/root_fs/etc/firewall.user
@@ -5,3 +5,10 @@
 # Internal uci firewall chains are flushed and recreated on reload, so
 # put custom rules into the root chains e.g. INPUT or FORWARD or into the
 # special user chains, e.g. input_wan_rule or postrouting_lan_rule.
+
+# Zyxel-Matrix note: fw3 is not shipped on this firmware. This file is executed by
+# /usr/sbin/apply-firewall-user at the end of boot (zyxel_lan), after every NAT flush
+# done by wifi-backhaul.sh and on every ifup of the WAN interface, so make every rule
+# idempotent, e.g.:
+#   iptables -C FORWARD -s 192.168.1.50 -o pppoe-wan -j DROP 2>/dev/null || \
+#     iptables -I FORWARD 1 -s 192.168.1.50 -o pppoe-wan -j DROP

--- a/root_fs/etc/hotplug.d/iface/21-firewall-user
+++ b/root_fs/etc/hotplug.d/iface/21-firewall-user
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Re-apply /etc/firewall.user whenever the WAN comes up (PPPoE reconnect, router reboot).
+# See /usr/sbin/apply-firewall-user for why fw3 does not do this on this firmware.
+
+[ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
+[ "$INTERFACE" = wan ] || exit 0
+
+/usr/sbin/apply-firewall-user "hotplug $ACTION $INTERFACE"

--- a/root_fs/etc/init.d/zyxel_lan
+++ b/root_fs/etc/init.d/zyxel_lan
@@ -106,5 +106,10 @@ start() {
                                 usr/bin/wifi-backhaul.sh &
 
 
+
+        # Custom user rules (/etc/firewall.user). fw3 is not shipped on this firmware, so
+        # nothing else would ever run them. See /usr/sbin/apply-firewall-user.
+        /usr/sbin/apply-firewall-user boot
+
                 echo " 100%  Ready! - Press any key to login ...]" > /dev/console
 }

--- a/root_fs/usr/bin/wifi-backhaul.sh
+++ b/root_fs/usr/bin/wifi-backhaul.sh
@@ -18,6 +18,8 @@ if [ "$ENABLED" != "1" ]; then
     
     chroot /tmp/zyxel_root /usr/sbin/iptables -t nat -F
     chroot /tmp/zyxel_root /usr/sbin/iptables -t nat -A POSTROUTING -o nas10 -j MASQUERADE
+    # NAT was flushed above: put the user's custom rules back.
+    /usr/sbin/apply-firewall-user "backhaul (mesh disabled)"
     exit 0
 fi
 
@@ -76,6 +78,8 @@ chroot /tmp/zyxel_root /usr/sbin/iptables -t nat -A POSTROUTING -o nas10 -j MASQ
 chroot /tmp/zyxel_root /usr/sbin/iptables -t nat -A POSTROUTING -o br-mesh -j MASQUERADE
 chroot /tmp/zyxel_root /usr/sbin/iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 chroot /tmp/zyxel_root /usr/sbin/iptables -P FORWARD ACCEPT
+# NAT was flushed above: put the user's custom rules back.
+/usr/sbin/apply-firewall-user "backhaul (mesh enabled)"
 echo 1 > /proc/sys/net/ipv4/ip_forward
 #leave it
 #echo 1 > /proc/tc3162/hwnat_off

--- a/root_fs/usr/sbin/apply-firewall-user
+++ b/root_fs/usr/sbin/apply-firewall-user
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Apply the user's custom firewall rules (/etc/firewall.user, also edited from
+# LuCI -> Network -> Firewall -> Custom Rules).
+#
+# On this firmware the OpenWrt firewall service (/etc/init.d/firewall, fw3) is not
+# shipped: netfilter is driven by the Zyxel side (zyxel_lan / wifi-backhaul.sh through the
+# chroot). Nothing ever executed /etc/firewall.user, so custom rules were silently lost on
+# every boot. This helper runs it at the end of zyxel_lan, after every NAT flush done by
+# wifi-backhaul.sh and on every ifup of the WAN interface (hotplug).
+#
+# Rules in /etc/firewall.user MUST be idempotent (the file is run several times):
+#   iptables -C FORWARD -s 192.168.1.50 -o pppoe-wan -j DROP 2>/dev/null || \
+#     iptables -I FORWARD 1 -s 192.168.1.50 -o pppoe-wan -j DROP
+
+REASON="${1:-manual}"
+[ -f /etc/firewall.user ] || exit 0
+logger -t firewall "Applying /etc/firewall.user ($REASON)"
+sh /etc/firewall.user


### PR DESCRIPTION
## Run `/etc/firewall.user` (it was never executed) and keep a usable log buffer

### Problem

The rootfs does not ship the OpenWrt firewall service: `usr/lib/opkg/info/firewall.list`
lists `/etc/init.d/firewall`, but the file is missing and there is no `S19firewall` in
`etc/rc.d/`. netfilter is configured imperatively by the Zyxel side (`zyxel_lan`,
`wifi-backhaul.sh` through the chroot). Consequences:

- `/etc/firewall.user` — which LuCI still exposes as *Network → Firewall → Custom Rules* — is
  never executed. Rules added there work until the next reboot and then vanish silently.
- `etc/hotplug.d/iface/20-firewall` bails out at `/etc/init.d/firewall enabled`, so nothing
  re-applies user rules after a PPPoE reconnect either.
- `wifi-backhaul.sh` runs `iptables -t nat -F`, wiping any NAT rule a user managed to add.

On my unit this bit me twice: a per-device "no Internet" DROP for an IoT module disappeared
after an unattended reboot and the device went back online without anyone noticing.

The default `logd` buffer (16 KiB, `log_size` unset) holds roughly two minutes of `zcmd`
chatter, which makes any reboot investigation impossible.

### Changes

- **`usr/sbin/apply-firewall-user`** (new): logs and runs `/etc/firewall.user` if present.
- **`etc/init.d/zyxel_lan`**: calls it at the very end of `start()`, after the Zyxel iptables
  setup and after `wifi-backhaul.sh` has been launched.
- **`usr/bin/wifi-backhaul.sh`**: calls it right after each `iptables -t nat -F` block (mesh
  enabled and disabled paths).
- **`etc/hotplug.d/iface/21-firewall-user`** (new): re-applies on `ifup`/`ifupdate` of `wan`.
- **`etc/firewall.user`**: header explains that the file runs several times and shows an
  idempotent `iptables -C … || iptables -I …` example.
- **`etc/config/system`**: `option log_size '256'`.
- **README**: new section "Custom firewall rules and logging" (also how to ship the log to a
  LAN syslog receiver, which is what finally let me see what happens before a reboot).

No change to the Zyxel binaries or to the chroot; the helper only shells out to the user's
file. Line endings kept as CRLF like the rest of `root_fs/`.

### Notes for the maintainer

- `tools/root_fs_part*.tar` is not touched here (30 MB × 3, not reviewable in a PR). If
  `repack_firmware_v17` builds from the tars rather than from `root_fs/`, the two new files
  and the four edits need to be copied into the tars when regenerating them.
- Tested on an EX3301-T0 running Zyxel-Matrix 1.0.1 (r48532): `apply-firewall-user` installed
  live and run by hand and through `ACTION=ifup INTERFACE=wan sh 21-firewall-user`; both log
  `firewall: Applying /etc/firewall.user (...)` and re-install the rules idempotently
  (`iptables -L FORWARD -n` shows the same rule count before/after); `INTERFACE=lan` is
  ignored. The `zyxel_lan` / `wifi-backhaul.sh` call sites were reviewed but not exercised by a
  reboot on my unit yet.
